### PR TITLE
feat: add phpMyAdmin to improve development workflow

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,5 +29,16 @@ services:
       interval: 10s
       timeout: 5s
       retries: 5
+  phpmyadmin:
+    image: phpmyadmin/phpmyadmin
+    ports:
+      - "8081:80"
+    environment:
+      PMA_HOST: db
+      PMA_USER: ${MYSQL_USER}
+      PMA_PASSWORD: ${MYSQL_PASSWORD}
+    depends_on:
+      - db
+
 volumes:
   db-data:


### PR DESCRIPTION
- Added phpMyAdmin service to docker-compose.yml for easier database management during development.
phpMyAdmin offers a web interface to browse tables, run queries, and manage the MySQL database without the command line.

- This setup prepares the project for future use of phpMyAdmin to aid debugging and local testing.

- The service connects directly to the 'db' MySQL container within the same Docker network. Without this, phpMyAdmin couldn't resolve the db hostname.

- Now accessible at http://localhost:8081/, phpMyAdmin simplifies database access and maintenance.